### PR TITLE
Upgrade TraderJoe V2

### DIFF
--- a/.openzeppelin/avalanche.json
+++ b/.openzeppelin/avalanche.json
@@ -5874,6 +5874,336 @@
           }
         }
       }
+    },
+    "a1be6554dfdaf7f8dd487d54c559c6c1c1ed04a1284d9256e4627c158d26b356": {
+      "address": "0xA81c4DbCd4c58E7DDffBe1394838a8C44Db57AB1",
+      "txHash": "0x93e1afc44d2956a1174352bc9fa086631400b27f1457f69788cfb14f5e7f779a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "withdrawalFee",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_uint24",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:11"
+          },
+          {
+            "label": "depositFee",
+            "offset": 3,
+            "slot": "351",
+            "type": "t_uint24",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:12"
+          },
+          {
+            "label": "performanceFee",
+            "offset": 6,
+            "slot": "351",
+            "type": "t_uint24",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:13"
+          },
+          {
+            "label": "currentAccumulatedFee",
+            "offset": 0,
+            "slot": "352",
+            "type": "t_uint256",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:14"
+          },
+          {
+            "label": "claimedFee",
+            "offset": 0,
+            "slot": "353",
+            "type": "t_uint256",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:15"
+          },
+          {
+            "label": "feeReceiver",
+            "offset": 0,
+            "slot": "354",
+            "type": "t_address",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:16"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "355",
+            "type": "t_array(t_uint256)40_storage",
+            "contract": "FeeUpgradeable",
+            "src": "contracts/common/bases/FeeUpgradeable.sol:17"
+          },
+          {
+            "label": "totalInvestmentLimit",
+            "offset": 0,
+            "slot": "395",
+            "type": "t_uint256",
+            "contract": "InvestmentLimitUpgradeable",
+            "src": "contracts/common/bases/InvestmentLimitUpgradeable.sol:12"
+          },
+          {
+            "label": "investmentLimitPerAddress",
+            "offset": 0,
+            "slot": "396",
+            "type": "t_uint256",
+            "contract": "InvestmentLimitUpgradeable",
+            "src": "contracts/common/bases/InvestmentLimitUpgradeable.sol:13"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "397",
+            "type": "t_array(t_uint256)8_storage",
+            "contract": "InvestmentLimitUpgradeable",
+            "src": "contracts/common/bases/InvestmentLimitUpgradeable.sol:14"
+          },
+          {
+            "label": "investmentToken",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_contract(IInvestmentToken)22504",
+            "contract": "StrategyBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyBaseUpgradeable.sol:53"
+          },
+          {
+            "label": "depositToken",
+            "offset": 0,
+            "slot": "406",
+            "type": "t_contract(IERC20Upgradeable)6756",
+            "contract": "StrategyBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyBaseUpgradeable.sol:54"
+          },
+          {
+            "label": "priceOracle",
+            "offset": 0,
+            "slot": "407",
+            "type": "t_contract(IPriceOracle)22651",
+            "contract": "StrategyBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyBaseUpgradeable.sol:55"
+          },
+          {
+            "label": "swapService",
+            "offset": 0,
+            "slot": "408",
+            "type": "t_struct(SwapService)22911_storage",
+            "contract": "StrategyBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyBaseUpgradeable.sol:56"
+          },
+          {
+            "label": "uninvestedDepositTokenAmount",
+            "offset": 0,
+            "slot": "409",
+            "type": "t_uint256",
+            "contract": "StrategyBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyBaseUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "410",
+            "type": "t_array(t_uint256)7_storage",
+            "contract": "StrategyBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyBaseUpgradeable.sol:58"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "417",
+            "type": "t_array(t_uint256)8_storage",
+            "contract": "StrategyOwnableBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyOwnableBaseUpgradeable.sol:12"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "425",
+            "type": "t_array(t_uint256)4_storage",
+            "contract": "StrategyOwnablePausableBaseUpgradeable",
+            "src": "contracts/common/bases/StrategyOwnablePausableBaseUpgradeable.sol:12"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)40_storage": {
+            "label": "uint256[40]",
+            "numberOfBytes": "1280"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)4_storage": {
+            "label": "uint256[4]",
+            "numberOfBytes": "128"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)7_storage": {
+            "label": "uint256[7]",
+            "numberOfBytes": "224"
+          },
+          "t_array(t_uint256)8_storage": {
+            "label": "uint256[8]",
+            "numberOfBytes": "256"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IERC20Upgradeable)6756": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IInvestmentToken)22504": {
+            "label": "contract IInvestmentToken",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IPriceOracle)22651": {
+            "label": "contract IPriceOracle",
+            "numberOfBytes": "20"
+          },
+          "t_enum(SwapServiceProvider)22905": {
+            "label": "enum SwapServiceProvider",
+            "members": ["TraderJoe", "TraderJoeV2"],
+            "numberOfBytes": "1"
+          },
+          "t_struct(SwapService)22911_storage": {
+            "label": "struct SwapService",
+            "members": [
+              {
+                "label": "provider",
+                "type": "t_enum(SwapServiceProvider)22905",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "router",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint24": {
+            "label": "uint24",
+            "numberOfBytes": "3"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Migration from V1 to V2 with git tag `traderjoe_strategy_v1.2.1`.