### PR TITLE
Use traderjoe v2 for stablecoin swap

### DIFF
--- a/configs/deploy/portfolio/Calm.json
+++ b/configs/deploy/portfolio/Calm.json
@@ -27,7 +27,8 @@
         { "$ref": "../../../constants/addresses/Stargate.json#/usdcPool" },
         { "$ref": "../../../constants/addresses/Stargate.json#/lpStaking" },
         { "$ref": "../../../constants/addresses/Stargate.json#/usdcLPToken" },
-        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" }
+        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" },
+        [{ "$ref": "../../../constants/addresses/TraderJoe.json#/lbRouter" }, 1]
       ],
       "libraries": []
     },
@@ -106,7 +107,8 @@
         { "$ref": "../../../constants/addresses/Stargate.json#/usdtPool" },
         { "$ref": "../../../constants/addresses/Stargate.json#/lpStaking" },
         { "$ref": "../../../constants/addresses/Stargate.json#/usdtLPToken" },
-        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" }
+        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" },
+        [{ "$ref": "../../../constants/addresses/TraderJoe.json#/lbRouter" }, 1]
       ],
       "libraries": []
     },

--- a/configs/deploy/strategy/StargateUSDC.json
+++ b/configs/deploy/strategy/StargateUSDC.json
@@ -27,7 +27,8 @@
         { "$ref": "../../../constants/addresses/Stargate.json#/usdcPool" },
         { "$ref": "../../../constants/addresses/Stargate.json#/lpStaking" },
         { "$ref": "../../../constants/addresses/Stargate.json#/usdcLPToken" },
-        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" }
+        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" },
+        [{ "$ref": "../../../constants/addresses/TraderJoe.json#/lbRouter" }, 1]
       ],
       "libraries": []
     }

--- a/configs/deploy/strategy/StargateUSDT.json
+++ b/configs/deploy/strategy/StargateUSDT.json
@@ -27,7 +27,8 @@
         { "$ref": "../../../constants/addresses/Stargate.json#/usdtPool" },
         { "$ref": "../../../constants/addresses/Stargate.json#/lpStaking" },
         { "$ref": "../../../constants/addresses/Stargate.json#/usdtLPToken" },
-        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" }
+        { "$ref": "../../../constants/addresses/Stargate.json#/stgToken" },
+        [{ "$ref": "../../../constants/addresses/TraderJoe.json#/lbRouter" }, 1]
       ],
       "libraries": []
     }

--- a/configs/upgrade/strategy/StargateUSDC.json
+++ b/configs/upgrade/strategy/StargateUSDC.json
@@ -2,7 +2,9 @@
   "properties": [
     {
       "proxy": { "$ref": "../../live/strategy/StargateUSDC.json#/address" },
-      "newImplementation": "Stargate"
+      "newImplementation": "Stargate",
+      "functionName": "reinitialize",
+      "functionArgs": [[{ "$ref": "../../../constants/addresses/TraderJoe.json#/lbRouter" }, 1]]
     }
   ]
 }

--- a/configs/upgrade/strategy/StargateUSDT.json
+++ b/configs/upgrade/strategy/StargateUSDT.json
@@ -2,7 +2,9 @@
   "properties": [
     {
       "proxy": { "$ref": "../../live/strategy/StargateUSDT.json#/address" },
-      "newImplementation": "Stargate"
+      "newImplementation": "Stargate",
+      "functionName": "reinitialize",
+      "functionArgs": [[{ "$ref": "../../../constants/addresses/TraderJoe.json#/lbRouter" }, 1]]
     }
   ]
 }

--- a/contracts/strategies/stargate/Stargate.sol
+++ b/contracts/strategies/stargate/Stargate.sol
@@ -20,10 +20,11 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
 
     // solhint-disable-next-line const-name-snakecase
     string public constant trackingName =
-        "brokkr.stargate_strategy.stargate_strategy_v1.1.1";
+        "brokkr.stargate_strategy.stargate_strategy_v1.1.2";
     // solhint-disable-next-line const-name-snakecase
     string public constant humanReadableName = "Stargate Strategy";
     // solhint-disable-next-line const-name-snakecase
+    string public constant version = "1.1.2";
 
     struct StargateArgs {
         address traderjoeLBRouter;

--- a/contracts/strategies/stargate/Stargate.sol
+++ b/contracts/strategies/stargate/Stargate.sol
@@ -14,6 +14,7 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
     using SafeERC20Upgradeable for IInvestmentToken;
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
+    error InvalidBinStep();
     error InvalidStargateLpToken();
     error NotEnoughDeltaCredit();
 
@@ -23,7 +24,11 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
     // solhint-disable-next-line const-name-snakecase
     string public constant humanReadableName = "Stargate Strategy";
     // solhint-disable-next-line const-name-snakecase
-    string public constant version = "1.1.1";
+
+    struct StargateArgs {
+        address traderjoeLBRouter;
+        uint256 binStep;
+    }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -36,7 +41,8 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
         IStargatePool pool,
         IStargateLpStaking lpStaking,
         IERC20Upgradeable lpToken,
-        IERC20Upgradeable stgToken
+        IERC20Upgradeable stgToken,
+        StargateArgs calldata stargateArgs
     ) external initializer {
         __UUPSUpgradeable_init();
         __StrategyOwnablePausableBaseUpgradeable_init(strategyArgs);
@@ -68,6 +74,15 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
         if (!isPoolFound) {
             revert InvalidStargateLpToken();
         }
+
+        __switchSwapService(stargateArgs);
+    }
+
+    function reinitialize(StargateArgs calldata stargateArgs)
+        external
+        reinitializer(2)
+    {
+        __switchSwapService(stargateArgs);
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
@@ -81,17 +96,10 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
             .getStorage();
 
         if (depositToken != strategyStorage.poolDepositToken) {
-            address[] memory path = new address[](3);
-            path[0] = address(depositToken);
-            path[1] = address(InvestableLib.AVALANCHE_WAVAX);
-            path[2] = address(strategyStorage.poolDepositToken);
-
-            amount = SwapServiceLib.swapExactTokensForTokens(
-                swapService,
+            amount = __swapTokens(
                 amount,
-                0,
-                path,
-                new uint256[](0)
+                depositToken,
+                strategyStorage.poolDepositToken
             );
         }
 
@@ -157,17 +165,11 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
         if (depositToken != strategyStorage.poolDepositToken) {
             uint256 poolDepositTokenBalanceIncrement = poolDepositTokenBalanceAfter -
                     poolDepositTokenBalanceBefore;
-            address[] memory path = new address[](3);
-            path[0] = address(strategyStorage.poolDepositToken);
-            path[1] = address(InvestableLib.AVALANCHE_WAVAX);
-            path[2] = address(depositToken);
 
-            SwapServiceLib.swapExactTokensForTokens(
-                swapService,
+            __swapTokens(
                 poolDepositTokenBalanceIncrement,
-                0,
-                path,
-                new uint256[](0)
+                strategyStorage.poolDepositToken,
+                depositToken
             );
         }
     }
@@ -178,16 +180,10 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
 
         strategyStorage.lpStaking.deposit(strategyStorage.farmId, 0);
 
-        address[] memory path = new address[](2);
-        path[0] = address(strategyStorage.stgToken);
-        path[1] = address(depositToken);
-
-        SwapServiceLib.swapExactTokensForTokens(
-            swapService,
+        __swapTokens(
             strategyStorage.stgToken.balanceOf(address(this)),
-            0,
-            path,
-            new uint256[](0)
+            strategyStorage.stgToken,
+            depositToken
         );
     }
 
@@ -265,5 +261,72 @@ contract Stargate is UUPSUpgradeable, StrategyOwnablePausableBaseUpgradeable {
                 .lpStaking
                 .userInfo(strategyStorage.farmId, address(this))
                 .amount;
+    }
+
+    function setBinStep(
+        IERC20Upgradeable tokenX,
+        IERC20Upgradeable tokenY,
+        uint256 binStep
+    ) public onlyOwner {
+        StargateStorage storage strategyStorage = StargateStorageLib
+            .getStorage();
+
+        strategyStorage.binSteps[tokenX][tokenY] = binStep;
+        strategyStorage.binSteps[tokenY][tokenX] = binStep;
+    }
+
+    function __swapTokens(
+        uint256 amountIn,
+        IERC20Upgradeable tokenIn,
+        IERC20Upgradeable tokenOut
+    ) private returns (uint256 amountOut) {
+        StargateStorage storage strategyStorage = StargateStorageLib
+            .getStorage();
+
+        address[] memory path = new address[](2);
+        path[0] = address(tokenIn);
+        path[1] = address(tokenOut);
+
+        uint256[] memory binStep = new uint256[](1);
+        binStep[0] = strategyStorage.binSteps[tokenIn][tokenOut];
+
+        SwapService memory _swapService;
+
+        // We switched to TraderJoe V2 for swapping since Stargate USDT v1.1.2,
+        // but $STG is not supported at the moment.
+        // The `binStep[0] == 0` condition will enable us to use TraderJoe V2
+        // for swapping $STG once it is supported without requiring an upgrade.
+        if (tokenIn == strategyStorage.stgToken && binStep[0] == 0) {
+            _swapService = strategyStorage.swapServiceForStgToken;
+        } else {
+            _swapService = swapService;
+        }
+
+        amountOut = SwapServiceLib.swapExactTokensForTokens(
+            _swapService,
+            amountIn,
+            0,
+            path,
+            binStep
+        );
+    }
+
+    function __switchSwapService(StargateArgs calldata stargateArgs) private {
+        StargateStorage storage strategyStorage = StargateStorageLib
+            .getStorage();
+
+        // $STG token is not supported by TraderJoe V2 yet.
+        strategyStorage.swapServiceForStgToken = swapService;
+
+        setSwapService(
+            SwapServiceProvider.AvalancheTraderJoeV2,
+            stargateArgs.traderjoeLBRouter
+        );
+
+        setBinStep(
+            depositToken,
+            strategyStorage.poolDepositToken,
+            stargateArgs.binStep
+        );
     }
 }

--- a/contracts/strategies/stargate/StargateStorageLib.sol
+++ b/contracts/strategies/stargate/StargateStorageLib.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import "../../common/libraries/SwapServiceLib.sol";
 import "../../dependencies/stargate/IStargateLpStaking.sol";
 import "../../dependencies/stargate/IStargatePool.sol";
 import "../../dependencies/stargate/IStargateRouter.sol";
@@ -16,6 +17,8 @@ struct StargateStorage {
     IERC20Upgradeable stgToken;
     uint256 poolId;
     uint256 farmId;
+    SwapService swapServiceForStgToken; // $STG is not supported by TraderJoe V2 yet.
+    mapping(IERC20Upgradeable => mapping(IERC20Upgradeable => uint256)) binSteps;
 }
 
 library StargateStorageLib {

--- a/test/strategies/stargate/Stargate.test.ts
+++ b/test/strategies/stargate/Stargate.test.ts
@@ -1,8 +1,9 @@
 import { expect } from "chai"
 import { BigNumber } from "ethers"
 import { ethers, upgrades } from "hardhat"
-import Tokens from "../../../constants/addresses/Tokens.json"
 import Stargate from "../../../constants/addresses/Stargate.json"
+import Tokens from "../../../constants/addresses/Tokens.json"
+import TraderJoe from "../../../constants/addresses/TraderJoe.json"
 import { deployStrategy, upgradeStrategy } from "../../../scripts/helper/contract"
 import StargateLPTokenABI from "../../helper/abi/StargateLPToken.json"
 import { TestOptions } from "../../helper/interfaces/options"
@@ -197,6 +198,7 @@ function testStargateUSDCInitialize() {
             Stargate.lpStaking,
             Tokens.usdc,
             Stargate.stgToken,
+            [TraderJoe.lbRouter, 1],
           ],
           { kind: "uups" }
         )
@@ -357,6 +359,7 @@ function testStargateUSDTInitialize() {
             Stargate.lpStaking,
             Tokens.usdc,
             Stargate.stgToken,
+            [TraderJoe.lbRouter, 1],
           ],
           { kind: "uups" }
         )


### PR DESCRIPTION
Using TraderJoe V2 for USDC-USDT swap reduces swap fee. However, $STG is not supported by TraderJoe V2 at the moment. So we keep using TraderJoe V1 for $STG swapping.

Once it is supported by TraderJoe V2, we can use TraderJoe V2 for $STG swapping by calling `setBinStep` without any upgrade.